### PR TITLE
fix: phase 8 — footer CTA alignment and divider fixes

### DIFF
--- a/.migration/journal/journal.md
+++ b/.migration/journal/journal.md
@@ -5,6 +5,29 @@
 
 ---
 
+## Session: 2026-04-01 — Footer Divider Color Fix & Deploy Investigation
+
+**Duration**: ~10m
+**Branch**: `phase8-updates`
+**Commit**: `75b6e80`
+
+### Summary
+
+1. **Divider color fix** (`75b6e80`): Changed footer CTA divider pseudo-element color from `rgb(255 255 255 / 30%)` to `rgb(128 128 128)` to match the original's solid gray HR color.
+
+2. **Deploy investigation**: User reported changes not appearing on live site (`main--summit-nrg--aemdemos.aem.page`). Verified all commits are pushed to `phase8-updates` remote branch. Found no PR exists for phase8 → main yet. The phase8 changes haven't been merged to `main`, which explains why the live site doesn't reflect them.
+
+### Files Changed
+
+- `blocks/footer/footer.css` — divider color update
+
+### Status
+
+- All 3 phase8 commits pushed to remote `phase8-updates` branch
+- PR to merge into `main` still needs to be created
+
+---
+
 ## Session: 2026-03-30 — Footer CTA Alignment & Divider Fixes
 
 **Duration**: ~25m

--- a/.migration/journal/journal.md
+++ b/.migration/journal/journal.md
@@ -5,6 +5,19 @@
 
 ---
 
+## Session: 2026-03-30 — Daily Update + Phase 8 Branch Setup
+
+**Duration**: ~10m
+**Branch**: `main` → `phase8-updates`
+
+### Summary
+
+Ran daily update: 0 open issues, 0 open PRs, lint clean (0 errors, 2 pre-existing warnings), Stylelint clean. Captured full-page desktop (1440px) and mobile (375px) screenshots. Total project effort: ~26.5h across 46 sessions. Project is in maintenance mode with all known issues resolved.
+
+Created `phase8-updates` branch for next round of work.
+
+---
+
 ## Daily Update: 2026-03-30
 
 **Branch**: `main`

--- a/.migration/journal/journal.md
+++ b/.migration/journal/journal.md
@@ -5,6 +5,26 @@
 
 ---
 
+## Session: 2026-03-30 — Footer CTA Alignment & Divider Fixes
+
+**Duration**: ~25m
+**Branch**: `phase8-updates`
+**Commits**: `f32d2f1`, `a0c8d69`
+
+### Summary
+
+Two footer CTA column fixes on the `phase8-updates` branch:
+
+1. **Proportional left padding** (`f32d2f1`): Changed desktop `.footer-cta` padding-left from fixed `144px` to `10%`. The original NRG site uses 20% of column width (= 10% of viewport) so content scales proportionally at wider viewports. Verified exact match at 1440px (144px), 1920px (192px), and 2560px (256px).
+
+2. **Divider width & thickness** (`a0c8d69`): The HR between "Contact us" button and "Get the latest" section was spanning the full content wrapper (1000px at 2560px). Replaced the `border-top: 1px` on the second h3 with a `::before` pseudo-element: 306px wide (matching button width) and 2px thick (matching original HR).
+
+### Files Changed
+
+- `blocks/footer/footer.css` — proportional padding + constrained divider pseudo-element
+
+---
+
 ## Session: 2026-03-30 — Footer CTA Proportional Padding Fix
 
 **Duration**: ~20m

--- a/.migration/journal/journal.md
+++ b/.migration/journal/journal.md
@@ -5,6 +5,34 @@
 
 ---
 
+## Session: 2026-03-30 — Footer CTA Proportional Padding Fix
+
+**Duration**: ~20m
+**Branch**: `phase8-updates`
+**Commit**: `f32d2f1`
+
+### Summary
+
+Fixed the footer left purple (CTA) column alignment for wide viewports. The original NRG site uses proportional left padding (20% of column width = 10% of viewport) that scales with screen width. Our version used a fixed `144px` which matched at 1440px but drifted left on wider screens (1920px, 2560px+).
+
+**Root cause**: `padding-left: 144px` (fixed) vs original's proportional padding.
+
+**Fix**: Changed desktop `.footer-cta` padding from `72px 24px 72px 144px` to `72px 24px 72px 10%`.
+
+### Verification
+
+| Viewport | Original padding-left | Ours (after fix) | Match |
+|----------|----------------------|-------------------|-------|
+| 1440px   | 144px | 144px (10% of 1440) | Exact |
+| 1920px   | 192px | 192px (10% of 1920) | Exact |
+| 2560px   | 256px | 256px (10% of 2560) | Exact |
+
+### Files Changed
+
+- `blocks/footer/footer.css` — 1 line changed (desktop media query, line 261)
+
+---
+
 ## Session: 2026-03-30 — Daily Update + Phase 8 Branch Setup
 
 **Duration**: ~10m

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -258,7 +258,7 @@ footer .footer .footer-nav-col h3 {
   /* #71: reduce right padding so 'Get the latest' heading doesn't wrap */
   footer .footer .footer-cta {
     width: 50%;
-    padding: 72px 24px 72px 144px;
+    padding: 72px 24px 72px 10%;
   }
 
   /* desktop: restore light background and dark text */

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -51,7 +51,7 @@ footer .footer .footer-cta .default-content-wrapper h3:nth-of-type(2)::before {
   left: 0;
   width: 306px;
   height: 2px;
-  background-color: rgb(255 255 255 / 30%);
+  background-color: rgb(128 128 128);
 }
 
 /* CTA button — white outline pill */

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -37,11 +37,21 @@ footer .footer .footer-cta p {
   margin: 0 0 16px;
 }
 
-/* #72: divider between CTA and newsletter — match original (full-width HR) */
+/* #72: divider between CTA and newsletter — match original HR (306px wide, 2px thick) */
 footer .footer .footer-cta .default-content-wrapper h3:nth-of-type(2) {
-  border-top: 1px solid rgb(255 255 255 / 30%);
-  padding-top: 32px;
+  position: relative;
+  padding-top: 34px;
   margin-top: 32px;
+}
+
+footer .footer .footer-cta .default-content-wrapper h3:nth-of-type(2)::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 306px;
+  height: 2px;
+  background-color: rgb(255 255 255 / 30%);
 }
 
 /* CTA button — white outline pill */


### PR DESCRIPTION
## Summary

- **Proportional left padding**: Changed footer CTA `padding-left` from fixed `144px` to `10%` so content scales proportionally at wider viewports (matches original at 1440px, 1920px, 2560px)
- **Divider width**: Replaced full-width `border-top` on the second h3 with a `::before` pseudo-element constrained to 306px (matching Contact button width)
- **Divider thickness**: Changed from 1px to 2px to match original HR
- **Divider color**: Changed from `rgb(255 255 255 / 30%)` to `rgb(128 128 128)` to match original's solid gray HR

## Test URLs

- **Before (main):** https://main--summit-nrg--aemdemos.aem.page/
- **After (branch):** https://phase8-updates--summit-nrg--aemdemos.aem.page/

## Test plan

- [ ] Verify footer CTA left padding scales at 1440px, 1920px, and 2560px viewports
- [ ] Verify divider line is 306px wide (same as Contact button)
- [ ] Verify divider is 2px thick with solid gray color
- [ ] Check mobile layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)